### PR TITLE
Removed protocol from jQuery to allow https/etc

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
         <title>Superbowl Squares</title>
         <meta charset="UTF-8">
         <link rel="stylesheet" href="css/mystyle.css">
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
     </head>    
     <body>
         <?php include "getData.php"; ?>


### PR DESCRIPTION
If the script is run on a secure server and served over HTTPS, jQuery is blocked from loading due to the insecure http:// protocol specification. Changing the URI to begin with `//` allows it to simply be loaded via the same protocol as the page (since GoogleAPIs supports HTTPS this works quite well).